### PR TITLE
Add view ID to pointer events

### DIFF
--- a/examples/glfw_drm/FlutterEmbedderGLFW.cc
+++ b/examples/glfw_drm/FlutterEmbedderGLFW.cc
@@ -56,6 +56,9 @@ void GLFWcursorPositionCallbackAtPhase(GLFWwindow* window,
       std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::high_resolution_clock::now().time_since_epoch())
           .count();
+  // TODO(loicsharma): This assumes all pointer events are on the implicit
+  // view and should be updated to support multiple views.
+  event.view_id = 0;
   FlutterEngineSendPointerEvent(
       reinterpret_cast<FlutterEngine>(glfwGetWindowUserPointer(window)), &event,
       1);

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -395,10 +395,11 @@ class PlatformDispatcher {
 
   // If this value changes, update the encoding code in the following files:
   //
+  //  * pointer_data.h
   //  * pointer_data.cc
   //  * pointer.dart
   //  * AndroidTouchProcessor.java
-  static const int _kPointerDataFieldCount = 35;
+  static const int _kPointerDataFieldCount = 36;
 
   static PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
     const int kStride = Int64List.bytesPerElement;
@@ -444,6 +445,7 @@ class PlatformDispatcher {
         panDeltaY: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
         scale: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
         rotation: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        viewId: packet.getInt64(kStride * offset++, _kFakeHostEndian),
       ));
       assert(offset == (i + 1) * _kPointerDataFieldCount);
     }

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -176,6 +176,7 @@ class PointerData {
     this.panDeltaY = 0.0,
     this.scale = 0.0,
     this.rotation = 0.0,
+    this.viewId = 0,
   });
 
   /// Unique identifier that ties the [PointerEvent] to embedder event created it.
@@ -374,6 +375,9 @@ class PointerData {
   /// The current angle of the pan/zoom in radians, with 0.0 as the initial angle.
   final double rotation;
 
+  /// The identifier of the view this pointer event is for.
+  final int viewId;
+
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
 
@@ -413,7 +417,8 @@ class PointerData {
              'panDeltaX: $panDeltaX, '
              'panDeltaY: $panDeltaY, '
              'scale: $scale, '
-             'rotation: $rotation'
+             'rotation: $rotation, '
+             'viewId: $viewId '
            ')';
   }
 }

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -376,7 +376,7 @@ class PointerData {
   final double rotation;
 
   /// The identifier of the view this pointer event is for.
-  final int viewId;
+  final Object viewId;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -11,7 +11,7 @@ namespace flutter {
 
 // If this value changes, update the pointer data unpacking code in
 // platform_dispatcher.dart.
-static constexpr int kPointerDataFieldCount = 35;
+static constexpr int kPointerDataFieldCount = 36;
 static constexpr int kBytesPerField = sizeof(int64_t);
 // Must match the button constants in events.dart.
 enum PointerButtonMouse : int64_t {
@@ -32,7 +32,7 @@ enum PointerButtonStylus : int64_t {
   kPointerButtonStylusSecondary = 1 << 2,
 };
 
-// This structure is unpacked by hooks.dart.
+// This structure is unpacked by platform_dispatcher.dart.
 struct alignas(8) PointerData {
   // Must match the PointerChange enum in pointer.dart.
   enum class Change : int64_t {
@@ -100,6 +100,7 @@ struct alignas(8) PointerData {
   double pan_delta_y;
   double scale;
   double rotation;
+  int64_t view_id;
 
   void Clear();
 };

--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -69,7 +69,11 @@ void PointerDataPacketConverter::ConvertPointerData(
         break;
       }
       case PointerData::Change::kAdd: {
-        FML_DCHECK(states_.find(pointer_data.device) == states_.end());
+        // TODO(loicsharma): The macOS embedder does not share
+        // its mouse state across its view controllers, resulting
+        // in multiple pointer adds for the same pointer.
+        // See: https://github.com/flutter/flutter/issues/125931
+        // FML_DCHECK(states_.find(pointer_data.device) == states_.end());
         EnsurePointerState(pointer_data);
         converted_pointers.push_back(pointer_data);
         break;

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -129,6 +129,7 @@ void CreateSimulatedTrackpadGestureData(PointerData& data,  // NOLINT
   data.pan_delta_y = 0.0;
   data.scale = scale;
   data.rotation = rotation;
+  data.view_id = 0;
 }
 
 void UnpackPointerPacket(std::vector<PointerData>& output,  // NOLINT

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -71,6 +71,7 @@ class PointerData {
     this.panDeltaY = 0.0,
     this.scale = 0.0,
     this.rotation = 0.0,
+    this.viewId = 0,
   });
   final int embedderId;
   final Duration timeStamp;
@@ -107,6 +108,7 @@ class PointerData {
   final double panDeltaY;
   final double scale;
   final double rotation;
+  final int viewId;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
@@ -145,7 +147,8 @@ class PointerData {
            'panDeltaX: $panDeltaX, '
            'panDeltaY: $panDeltaY, '
            'scale: $scale, '
-           'rotation: $rotation'
+           'rotation: $rotation, '
+           'viewId: $viewId'
            ')';
   }
 }

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -108,7 +108,7 @@ class PointerData {
   final double panDeltaY;
   final double scale;
   final double rotation;
-  final int viewId;
+  final Object viewId;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -76,8 +76,8 @@ public class AndroidTouchProcessor {
     int UNKNOWN = 4;
   }
 
-  // Must match the unpacking code in hooks.dart.
-  private static final int POINTER_DATA_FIELD_COUNT = 35;
+  // Must match the unpacking code in platform_dispatcher.dart.
+  private static final int POINTER_DATA_FIELD_COUNT = 36;
   @VisibleForTesting static final int BYTES_PER_FIELD = 8;
 
   // This value must match the value in framework's platform_view.dart.
@@ -354,6 +354,9 @@ public class AndroidTouchProcessor {
     packet.putDouble(0.0); // pan_delta_y
     packet.putDouble(1.0); // scale
     packet.putDouble(0.0); // rotation
+    // TODO(loicsharma): This assumes all pointer events are on the implicit
+    // view and should be updated to support multiple views.
+    packet.putLong(0); // view_id
 
     if (isTrackpadPan && getPointerChangeForPanZoom(pointerChange) == PointerChange.PAN_ZOOM_END) {
       ongoingPans.remove(event.getPointerId(pointerIndex));

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1079,6 +1079,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     pointer_data.device = reinterpret_cast<int64_t>(touch);
 
+    // TODO(loicsharma): This assumes all pointer events are on the implicit
+    // view and should be updated to support multiple views.
+    pointer_data.view_id = 0;
+
     // Pointer will be generated in pointer_data_packet_converter.cc.
     pointer_data.pointer_identifier = 0;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -769,6 +769,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
       .device_kind = deviceKind,
       // If a click triggered a synthesized kAdd, don't pass the buttons in that event.
       .buttons = phase == kAdd ? 0 : _mouseState.buttons,
+      .view_id = static_cast<int64_t>(_viewId),
   };
 
   if (phase == kPanZoomUpdate) {
@@ -1049,6 +1050,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
           .device = kPointerPanZoomDeviceId,
           .signal_kind = kFlutterPointerSignalKindScrollInertiaCancel,
           .device_kind = kFlutterPointerDeviceKindTrackpad,
+          .view_id = static_cast<int64_t>(_viewId),
       };
 
       [_engine sendPointerEvent:flutterEvent];

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2280,6 +2280,9 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
     pointer_data.pan_delta_y = 0.0;
     pointer_data.scale = SAFE_ACCESS(current, scale, 0.0);
     pointer_data.rotation = SAFE_ACCESS(current, rotation, 0.0);
+    // TODO(loicsharma): The pointer event *must* have a view ID
+    // if implicit mode is disabled.
+    pointer_data.view_id = SAFE_ACCESS(current, view_id, 0);
     packet->SetPointerData(i, pointer_data);
     current = reinterpret_cast<const FlutterPointerEvent*>(
         reinterpret_cast<const uint8_t*>(current) + current->struct_size);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -936,6 +936,8 @@ typedef struct {
   double scale;
   /// The rotation of the pan/zoom in radians, where 0.0 is the initial angle.
   double rotation;
+  /// The identifier of the view that received the pointer event.
+  int64_t view_id;
 } FlutterPointerEvent;
 
 typedef enum {

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -388,6 +388,9 @@ static void SendPointerEventWithData(GLFWwindow* window,
   event.y *= pixels_per_coordinate;
   event.scroll_delta_x *= pixels_per_coordinate;
   event.scroll_delta_y *= pixels_per_coordinate;
+  // TODO(loicsharma): This assumes all pointer events are on the implicit
+  // view and should be updated to support multiple views.
+  event.view_id = 0;
 
   FlutterEngineSendPointerEvent(controller->engine->flutter_engine, &event, 1);
 

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -798,6 +798,9 @@ void fl_engine_send_pointer_pan_zoom_event(FlEngine* self,
   fl_event.rotation = rotation;
   fl_event.device = kPointerPanZoomDeviceId;
   fl_event.device_kind = kFlutterPointerDeviceKindTrackpad;
+  // TODO(loicsharma): This assumes all pointer events are on the implicit
+  // view and should be updated to support multiple views.
+  fl_event.view_id = 0;
   self->embedder_api.SendPointerEvent(self->engine, &fl_event, 1);
 }
 

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -407,6 +407,9 @@ void FlutterWindowsView::SendPointerPanZoomEnd(int32_t device_id) {
   event.x = state->pan_zoom_start_x;
   event.y = state->pan_zoom_start_y;
   event.phase = FlutterPointerPhase::kPanZoomEnd;
+  // TODO(loicsharma): This assumes all pointer events are on the implicit
+  // view and should be updated to support multiple views.
+  event.view_id = 0;
   SendPointerEventWithData(event, state);
 }
 
@@ -509,6 +512,9 @@ void FlutterWindowsView::SendPointerEventWithData(
   event.device_kind = state->device_kind;
   event.device = state->pointer_id;
   event.buttons = state->buttons;
+  // TODO(loicsharma): This assumes all pointer events are on the implicit
+  // view and should be updated to support multiple views.
+  event.view_id = 0;
 
   // Set metadata that's always the same regardless of the event.
   event.struct_size = sizeof(event);


### PR DESCRIPTION
Adds the view ID to the pointer events so that the framework can route them to the correct view. This requires embedder API changes and can't land on the upstream engine until after the engine spec is approved.

This change makes clicking work as expected across multiple views. However, hovering on multiple views does not work as expected. See: https://github.com/flutter/flutter/issues/125931

Prototype for: https://github.com/flutter/flutter/issues/112205

/cc @dkwingsmt @goderbauer

### Tests

✅ Clicking the `+` button now works on the multi-view counter app
❌ Hovering over the `+` button does not show a tooltip on the multi-view counter app

<details>
<summary>Patch to test this change on the playground...</summary>

```diff
diff --git a/lib/raw_dynamic.dart b/lib/raw_dynamic.dart
index 8a8c40a..ef4b032 100644
--- a/lib/raw_dynamic.dart
+++ b/lib/raw_dynamic.dart
@@ -6,10 +6,13 @@ import 'dart:math' as math;
 // This sample talks to dart:ui directly without utilizing the Flutter framework.
 import 'dart:ui';
 
+PointerDataPacket? _lastPointerDataPacket;
+
 void main() {
   PlatformDispatcher.instance
     ..onMetricsChanged = _handleOnMetricsChanged
-    ..onBeginFrame = _handleOnBeginFrame;
+    ..onBeginFrame = _handleOnBeginFrame
+    ..onPointerDataPacket = _handleOnPointerDataPacket;
   // If no view is available, the first frame wil be scheduled in
   // _handleOnMetricsChanged when a view is added.
   if (PlatformDispatcher.instance.views.isNotEmpty) {
@@ -36,7 +39,8 @@ void _handleOnBeginFrame(Duration timeStamp) {
       ..pushStyle(TextStyle(color: color))
       ..addText(
           'Timestamp: $timeStamp\n'
-          'View ID: ${view.viewId}',
+          'View ID: ${view.viewId}\n'
+          'Pointers: ${_pointers()}',
       );
     final Paragraph paragraph = paragraphBuilder.build()
       ..layout(ParagraphConstraints(width: logicalSize.width));
@@ -71,6 +75,22 @@ void _handleOnBeginFrame(Duration timeStamp) {
   }
 }
 
+void _handleOnPointerDataPacket(PointerDataPacket packet) {
+  _lastPointerDataPacket = packet;
+}
+
+String _pointers() {
+  final data = _lastPointerDataPacket?.data;
+  if (data == null) {
+    return '[]';
+  }
+
+  final pointers = data.map(
+    (p) => 'PointerData(x: ${p.physicalX}, y: ${p.physicalY}, viewId: ${p.viewId})',
+  );
+  return '[${pointers.join(', ')}]';
+}
+
 const List<Color> _colors = <Color>[
   Color(0xFF0092CC),
   Color(0xFFDCD427),
```

</details>